### PR TITLE
Add auto countdown for level transitions

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -77,6 +77,43 @@
             border-radius: 5px;
             cursor: pointer;
         }
+
+        #level-complete-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0,0,0,0.7);
+            display: none;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            color: white;
+            font-size: 2em;
+            z-index: 20;
+            opacity: 0;
+            transition: opacity 0.5s;
+        }
+
+        #level-complete-overlay.show {
+            display: flex;
+            animation: zoomIn 0.5s forwards;
+            opacity: 1;
+        }
+
+        #level-complete-overlay.fade-out {
+            animation: fadeOut 0.5s forwards;
+        }
+
+        @keyframes zoomIn {
+            from { transform: scale(0.8); opacity: 0; }
+            to { transform: scale(1); opacity: 1; }
+        }
+
+        @keyframes fadeOut {
+            to { opacity: 0; transform: scale(1.2); }
+        }
     </style>
 </head>
 <body class="flex flex-col items-center">
@@ -124,6 +161,7 @@
         let animalsLeft;
         let balloonInterval;
         let cloudInterval;
+        let countdownInterval;
         let savedAnimals = {};
         let usedPositions = [];
 
@@ -142,7 +180,13 @@
         function startGame() {
             clearInterval(balloonInterval);
             clearInterval(cloudInterval);
-            document.getElementById("game-container").innerHTML = "";
+            clearInterval(countdownInterval);
+            const container = document.getElementById("game-container");
+            container.innerHTML = `
+                <div id="level-complete-overlay">
+                    <div>Level Complete!</div>
+                    <div id="countdown"></div>
+                </div>`;
             animalsLeft = Math.max(10 + (level - 1), 0);
             savedAnimals = {};
             usedPositions = [];
@@ -153,6 +197,9 @@
             document.getElementById("animals-left").innerText = animalsLeft;
             updateSavedAnimalsDisplay();
             document.getElementById("next-level").style.display = "none";
+            const overlay = document.getElementById("level-complete-overlay");
+            overlay.style.display = "none";
+            overlay.classList.remove("show", "fade-out");
 
             updateAnimalValues();
             spawnClouds();
@@ -295,12 +342,33 @@
             }
         }
 
-        function endLevel() {
+       function endLevel() {
             clearInterval(balloonInterval);
             clearInterval(cloudInterval);
-            document.getElementById("next-level").style.display = "block";
+            document.getElementById("next-level").style.display = "none";
             setCookie("level", level, 7);
             setCookie("score", score, 7);
+            const overlay = document.getElementById("level-complete-overlay");
+            const countdownEl = document.getElementById("countdown");
+            overlay.classList.remove("fade-out");
+            overlay.classList.add("show");
+            overlay.style.display = "flex";
+            let count = 3;
+            countdownEl.innerText = count;
+            countdownInterval = setInterval(() => {
+                count--;
+                if (count > 0) {
+                    countdownEl.innerText = count;
+                } else {
+                    clearInterval(countdownInterval);
+                    overlay.classList.add("fade-out");
+                    setTimeout(() => {
+                        overlay.style.display = "none";
+                        overlay.classList.remove("show", "fade-out");
+                        nextLevel();
+                    }, 500);
+                }
+            }, 1000);
         }
 
         function nextLevel() {


### PR DESCRIPTION
## Summary
- add overlay with animation for level transitions
- automatically countdown before next level starts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840f9c4f5d88322817748ad8b97bfd5