### PR TITLE
Fix balloon selection after leaving screen

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -537,6 +537,9 @@
                                     easing: 'linear',
                                     complete: () => {
                                         balloonGroup.remove();
+                                        if (selectedBalloonGroup === balloonGroup) {
+                                            deselectBalloon();
+                                        }
                                         handleBalloonMiss(selectedAnimal);
                                         const idx = balloonAnimations.indexOf(anim);
                                         if (idx !== -1) balloonAnimations.splice(idx, 1);


### PR DESCRIPTION
## Summary
- ensure any selected balloon is deselected if it floats off the screen

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684c5d29a314832298422f4c5f06ae15