### PR TITLE
Fix shop modal layering

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -135,6 +135,11 @@
         @keyframes fadeOut {
             to { opacity: 0; transform: scale(1.2); }
         }
+
+        /* Ensure the shop modal appears above other overlays */
+        #shop-modal {
+            z-index: 60;
+        }
     </style>
 </head>
 <body class="flex flex-col items-center">


### PR DESCRIPTION
## Summary
- ensure shop modal renders above other overlays by giving it a higher z-index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c614f01448322b2331b0a7450d956