### PR TITLE
Update sound effects to shorter gentle clips

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -183,12 +183,12 @@
         <button id="album-btn" class="rounded px-2 py-1 bg-purple-600 text-white mt-2" onclick="openAlbum()">Animal Album</button>
     </div>
 
-<audio id="pop-sound" src="https://assets.mixkit.co/active_storage/sfx/2356/2356-preview.mp3"></audio>
-        <audio id="coin-sound" src="https://assets.mixkit.co/active_storage/sfx/1823/1823-preview.mp3"></audio>
-        <audio id="jackpot-sound" src="https://assets.mixkit.co/active_storage/sfx/595/595-preview.mp3"></audio>
-        <audio id="lightning-start-sound" src="https://assets.mixkit.co/active_storage/sfx/2094/2094-preview.mp3"></audio>
-        <audio id="fire-start-sound" src="https://assets.mixkit.co/active_storage/sfx/502/502-preview.mp3"></audio>
-        <audio id="ability-end-sound" src="https://assets.mixkit.co/active_storage/sfx/2876/2876-preview.mp3"></audio>
+        <audio id="pop-sound" data-volume="0.3" src="https://cdn.freesound.org/previews/570/570459_8258964-hq.mp3" preload="auto"></audio>
+        <audio id="coin-sound" data-volume="0.4" src="https://cdn.freesound.org/previews/583/583478_13157673-hq.mp3" preload="auto"></audio>
+        <audio id="jackpot-sound" data-volume="0.5" src="https://cdn.freesound.org/previews/400/400113_685248-hq.mp3" preload="auto"></audio>
+        <audio id="lightning-start-sound" data-volume="0.4" src="https://cdn.freesound.org/previews/264/264779_2886479-hq.mp3" preload="auto"></audio>
+        <audio id="fire-start-sound" data-volume="0.4" src="https://cdn.freesound.org/previews/506/506546_6142149-hq.mp3" preload="auto"></audio>
+        <audio id="ability-end-sound" data-volume="0.3" src="https://cdn.freesound.org/previews/405/405546_6436863-hq.mp3" preload="auto"></audio>
     <div id="animal-album-modal" class="hidden fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex items-center justify-center z-30">
         <div class="bg-white p-4 rounded w-72">
             <h3 class="text-xl mb-2 font-bold">Animal Album</h3>
@@ -310,7 +310,15 @@
             }
         };
 
-        function playSound(id){ const a=document.getElementById(id); if(a){ a.currentTime=0; a.play(); } }
+        function playSound(id){
+            const a = document.getElementById(id);
+            if(a){
+                a.currentTime = 0;
+                const vol = parseFloat(a.dataset.volume || '1');
+                a.volume = isNaN(vol) ? 1 : vol;
+                a.play();
+            }
+        }
 
         const AbilityManager = (() => {
             let active=null; let expires=0; let interval=null;


### PR DESCRIPTION
## Summary
- replace audio tracks with short, subtle clips from Freesound
- allow specifying volume via a data attribute
- adjust playSound to respect the per-sound volume

## Testing
- `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 https://cdn.freesound.org/previews/570/570459_8258964-hq.mp3`


------
https://chatgpt.com/codex/tasks/task_e_684d8e6492f48322b26472ce9097f396